### PR TITLE
Enhanced metadata and /media endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ bin/
 media/
 dist/
 pouch__all_dbs__/
-_media
+_media/
+casparcg.config

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ db.changes({
 ```
 
 ### Enhanced Metadata
-These endpoints provide additional metadata on media in a json format. They are only available if `metadata.enhanced` is enabled in the config.
+These endpoints provide additional metadata on media in a json format.
 
 * `/media` - Lists available media files in json form with an enhanced set of metadata
 * `/media/info/<name>` - Gets the json enhanced metadata for the specified media file

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Usage
 
 This project is designed to be used via the AMCP protocol in CasparCG server. However, there are some endpoints for additional data which can only be access directly over http.
 
+### Configuration
+There are various options that can be changed for the scanner. These can all be set by environment variables or as arguments.
+Some features are disabled by default and should be enabled in this way.
+
+To change options with arguments use the following syntax: `scanner.exe --metadata.scenes true --metadata.sceneThreshold 0.5`
+
+The full set of available options and their default values can be found at [config.js](src/config.js)
+
+By default the scanner expects there to be a casparcg.config file next to the executable to specify the paths to media. To disable use of this file `scanner.exe --caspar null`
+
 ### AMCP Endpoints
 These endpoints are exposed by the AMCP protocol in CasparCG Server. This means that they have some AMCP syntax wrappings, which will likely need to be stripped off if using in an external client
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ db.changes({
 });
 ```
 
+### Enhanced Metadata
+These endpoints provide additional metadata on media in a json format. They are only available if `metadata.enhanced` is enabled in the config.
+
+* `/media` - Lists available media files in json form with an enhanced set of metadata
+* `/media/info/<name>` - Gets the json enhanced metadata for the specified media file
+* `/media/thumbnail/<name>` - Gets the thumbnail for a media file
+
 
 Development
 -----------

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,6 +982,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.2"
+      }
+    },
     "couchdb-calculate-session-id": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/couchdb-calculate-session-id/-/couchdb-calculate-session-id-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scanner",
   "version": "1.0.0",
   "description": "",
-  "license" : "LGPL-3.0",
+  "license": "LGPL-3.0",
   "main": "index.js",
   "scripts": {
     "dev": "nodemon ./src",
@@ -14,6 +14,7 @@
   "dependencies": {
     "@reactivex/rxjs": "^5.5.6",
     "chokidar": "^2.0.0",
+    "cors": "^2.8.4",
     "express": "^4.16.2",
     "express-pouchdb": "^4.0.0",
     "mkdirp-promise": "^5.0.1",

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const pinoHttp = require('pino-http')
+const cors = require('cors')
 const PouchDB = require('pouchdb-node')
 const util = require('util')
 const recursiveReadDir = require('recursive-readdir')
@@ -13,6 +14,7 @@ module.exports = function ({ db, config, logger }) {
   const app = express()
 
   app.use(pinoHttp({ logger }))
+  app.use(cors())
 
   app.use('/db', require('express-pouchdb')(PouchDB, {
     mode: 'minimumForPouchDB'

--- a/src/app.js
+++ b/src/app.js
@@ -25,6 +25,7 @@ module.exports = function ({ db, config, logger }) {
       .map(row => row.doc.cinf || '')
       .reduce((acc, inf) => acc + inf, '')
 
+    res.set('content-type', 'text/plain')
     res.send(`200 CLS OK\r\n${str}\r\n`)
   }))
 
@@ -36,7 +37,8 @@ module.exports = function ({ db, config, logger }) {
       .filter(x => /\.(ft|wt|ct|html)$/.test(x))
       .map(x => `${getId(config.paths.template, x)}\r\n`)
       .reduce((acc, inf) => acc + inf, '')
-
+    
+    res.set('content-type', 'text/plain');
     res.send(`200 TLS OK\r\n${str}\r\n`)
   }))
 
@@ -48,21 +50,25 @@ module.exports = function ({ db, config, logger }) {
       .map(x => `${getId(config.paths.font, x)}\r\n`)
       .reduce((acc, inf) => acc + inf, '')
 
+    res.set('content-type', 'text/plain')
     res.send(`200 FLS OK\r\n${str}\r\n`)
   }))
 
   app.get('/cinf/:id', wrap(async (req, res) => {
     const { cinf } = await db.get(req.params.id.toUpperCase())
+    res.set('content-type', 'text/plain')
     res.send(`201 CINF OK\r\n${cinf}`)
   }))
 
   app.get('/thumbnail/generate', wrap(async (req, res) => {
     // TODO (fix) Force scanner to scan and wait?
+    res.set('content-type', 'text/plain')
     res.send(`202 THUMBNAIL GENERATE_ALL OK\r\n`)
   }))
 
   app.get('/thumbnail/generate/:id', wrap(async (req, res) => {
     // TODO (fix) Force scanner to scan and wait?
+    res.set('content-type', 'text/plain')
     res.send(`202 THUMBNAIL GENERATE OK\r\n`)
   }))
 
@@ -73,12 +79,14 @@ module.exports = function ({ db, config, logger }) {
       .map(row => row.doc.tinf || '')
       .reduce((acc, inf) => acc + inf, '')
 
+    res.set('content-type', 'text/plain')
     res.send(`200 THUMBNAIL LIST OK\r\n${str}\r\n`)
   }))
 
   app.get('/thumbnail/:id', wrap(async (req, res) => {
     const { _attachments } = await db.get(req.params.id.toUpperCase(), { attachments: true })
 
+    res.set('content-type', 'text/plain')
     res.send(`201 THUMBNAIL RETRIEVE OK\r\n${_attachments['thumb.png'].data}\r\n`)
   }))
 

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,11 @@ const defaults = {
     width: 256,
     height: -1
   },
+  metadata: {
+    enhanced: false, // Note: After changing this setting, you will want to delete the _media database folder
+    fieldOrder: false, // This is an expensive check, as it requires decoding the beginning of the video
+    fieldOrderScanDuration: 200 // Frames. Note: Needs sufficient motion (Not titlecard)
+  },
   isProduction: process.env.NODE_ENV === 'production',
   logger: {
     level: process.env.NODE_ENV === 'production' ? 'info' : 'trace',

--- a/src/config.js
+++ b/src/config.js
@@ -24,7 +24,6 @@ const defaults = {
     height: -1
   },
   metadata: {
-    enhanced: false, // Note: After changing this setting, you will want to delete the _media database folder
     fieldOrder: false, // This is an expensive check, as it requires decoding the beginning of the video
     fieldOrderScanDuration: 200 // Frames. Note: Needs sufficient motion (Not titlecard)
   },

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const logger = pino(Object.assign({}, config.logger, {
   }
 }))
 
-const db = new PouchDB(`http://localhost:${config.http.port}/db/_media`);
+const db = new PouchDB(`http://localhost:${config.http.port}/db/_media`)
 
 logger.info(config)
 

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -201,7 +201,7 @@ module.exports = function ({ config, db, logger }) {
 
     doc.cinf = generateCinf(doc, json)
 
-    if (config.metadata.enhanced) {
+    if (config.metadata !== null) {
       doc.mediainfo = await generateMediainfo(doc, json)
     }
   }
@@ -251,8 +251,8 @@ module.exports = function ({ config, db, logger }) {
           return reject(err)
         }
 
-        var regex2 = /Multi frame detection: TFF:\s+(\d+)\s+BFF:\s+(\d+)\s+Progressive:\s+(\d+)/
-        const res = regex2.exec(stderr)
+        const resultRegex = /Multi frame detection: TFF:\s+(\d+)\s+BFF:\s+(\d+)\s+Progressive:\s+(\d+)/
+        const res = resultRegex.exec(stderr)
         if (res === null) {
           return resolve('unknown')
         }

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -157,7 +157,7 @@ module.exports = function ({ config, db, logger }) {
 
     const thumbStat = await statAsync(tmpPath)
     doc.thumbSize = thumbStat.size
-    doc.thumbTime = thumbStat.mtime.toISOString()
+    doc.thumbTime = thumbStat.mtime.getTime()
     doc.tinf = [
       `"${getId(config.paths.media, doc.mediaPath)}"`,
       moment(doc.thumbTime).format('YYYYMMDDTHHmmss'),

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -49,7 +49,7 @@ module.exports = function ({ config, db, logger }) {
     logger.info('Checking for dead media')
 
     const limit = 256
-    let startkey = undefined
+    let startkey
     while (true) {
       const deleted = []
 
@@ -80,12 +80,13 @@ module.exports = function ({ config, db, logger }) {
           logger.error({ err, doc })
         }
       }))
+
+      await db.bulkDocs(deleted)
+
       if (rows.length < limit) {
         break
       }
-      startkey = rows[rows.length-1].doc._id
-
-      await db.bulkDocs(deleted)
+      startkey = rows[rows.length - 1].doc._id
     }
 
     logger.info(`Finished check for dead media`)
@@ -167,14 +168,14 @@ module.exports = function ({ config, db, logger }) {
     doc._attachments = {
       'thumb.png': {
         content_type: 'image/png',
-        data: (await readFileAsync(tmpPath)).toString('base64')
+        data: (await readFileAsync(tmpPath))
       }
     }
     await unlinkAsync(tmpPath)
   }
 
   async function generateInfo (doc) {
-    doc.cinf = await new Promise((resolve, reject) => {
+    const json = await new Promise((resolve, reject) => {
       const args = [
         // TODO (perf) Low priority process?
         config.paths.ffprobe,
@@ -194,28 +195,124 @@ module.exports = function ({ config, db, logger }) {
           return reject(new Error('not media'))
         }
 
-        let tb = (json.streams[0].time_base || '1/25').split('/')
-        let dur = parseFloat(json.format.duration) || (1 / 24)
-
-        let type = ' AUDIO '
-        if (json.streams[0].pix_fmt) {
-          type = dur <= (1 / 24) ? ' STILL ' : ' MOVIE '
-
-          const fr = String(json.streams[0].avg_frame_rate || json.streams[0].r_frame_rate || '').split('/')
-          if (fr.length === 2) {
-            tb = [ fr[1], fr[0] ]
-          }
-        }
-
-        resolve([
-          `"${getId(config.paths.media, doc.mediaPath)}"`,
-          type,
-          doc.mediaSize,
-          moment(doc.thumbTime).format('YYYYMMDDHHmmss'),
-          Math.floor((dur * tb[1]) / tb[0]),
-          `${tb[0]}/${tb[1]}`
-        ].join(' ') + '\r\n')
+        resolve(json)
       })
     })
+
+    doc.cinf = generateCinf(doc, json)
+
+    if (config.metadata.enhanced) {
+      doc.mediainfo = await generateMediainfo(doc, json)
+    }
+  }
+
+  function generateCinf (doc, json) {
+    let tb = (json.streams[0].time_base || '1/25').split('/')
+    let dur = parseFloat(json.format.duration) || (1 / 24)
+
+    let type = ' AUDIO '
+    if (json.streams[0].pix_fmt) {
+      type = dur <= (1 / 24) ? ' STILL ' : ' MOVIE '
+
+      const fr = String(json.streams[0].avg_frame_rate || json.streams[0].r_frame_rate || '').split('/')
+      if (fr.length === 2) {
+        tb = [ fr[1], fr[0] ]
+      }
+    }
+
+    return [
+      `"${getId(config.paths.media, doc.mediaPath)}"`,
+      type,
+      doc.mediaSize,
+      moment(doc.thumbTime).format('YYYYMMDDHHmmss'),
+      Math.floor((dur * tb[1]) / tb[0]) || 0,
+      `${tb[0]}/${tb[1]}`
+    ].join(' ') + '\r\n'
+  }
+
+  async function generateMediainfo (doc, json) {
+    const fieldOrder = await new Promise((resolve, reject) => {
+      if (!config.metadata.fieldOrder) {
+        return resolve('unknown')
+      }
+
+      const args = [
+        // TODO (perf) Low priority process?
+        config.paths.ffmpeg,
+        '-hide_banner',
+        '-filter:v', 'idet',
+        '-frames:v', config.metadata.fieldOrderScanDuration,
+        '-an',
+        '-f', 'rawvideo', '-y', (process.platform === 'win32' ? 'NUL' : '/dev/null'),
+        '-i', `"${doc.mediaPath}"`
+      ]
+      cp.exec(args.join(' '), (err, stdout, stderr) => {
+        if (err) {
+          return reject(err)
+        }
+
+        var regex2 = /Multi frame detection: TFF:\s+(\d+)\s+BFF:\s+(\d+)\s+Progressive:\s+(\d+)/
+        const res = regex2.exec(stderr)
+        if (res === null) {
+          return resolve('unknown')
+        }
+
+        const tff = parseInt(res[1])
+        const bff = parseInt(res[2])
+        const fieldOrder = tff <= 10 && bff <= 10 ? 'progressive' : (tff > bff ? 'tff' : 'bff')
+
+        resolve(fieldOrder)
+      })
+    })
+
+    return {
+      name: doc._id,
+      field_order: fieldOrder,
+
+      streams: json.streams.map(s => ({
+        codec: {
+          long_name: s.codec_long_name,
+          type: s.codec_type,
+          time_base: s.codec_time_base,
+          tag_string: s.codec_tag_string,
+          is_avc: s.is_avc
+        },
+
+        // Video
+        width: s.width,
+        height: s.height,
+        sample_aspect_ratio: s.sample_aspect_ratio,
+        display_aspect_ratio: s.display_aspect_ratio,
+        pix_fmt: s.pix_fmt,
+        bits_per_raw_sample: s.bits_per_raw_sample,
+
+        // Audio
+        sample_fmt: s.sample_fmt,
+        sample_rate: s.sample_rate,
+        channels: s.channels,
+        channel_layout: s.channel_layout,
+        bits_per_sample: s.bits_per_sample,
+
+        // Common
+        time_base: s.time_base,
+        start_time: s.start_time,
+        duration_ts: s.duration_ts,
+        duration: s.duration,
+
+        bit_rate: s.bit_rate,
+        max_bit_rate: s.max_bit_rate,
+        nb_frames: s.nb_frames
+      })),
+      format: {
+        name: json.format.format_name,
+        long_name: json.format.format_long_name,
+        size: json.format.time,
+
+        start_time: json.format.start_time,
+        duration: json.format.duration,
+        bit_rate: json.format.bit_rate,
+        max_bit_rate: json.format.max_bit_rate
+      }
+    }
   }
 }


### PR DESCRIPTION
This adds some /media endpoints which return json information on the media. Defaults to disabled as it is only useful to those who will connect to the scanner directly.

This also sets the content-types of the other endpoints to text/plain.
And fixes a bug from #19 where nothing stale would be deleted from the last page