### PR TITLE
fix: unnecessary rescans on startup

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -60,7 +60,9 @@ module.exports = function ({ config, db, logger }) {
       })
       await Promise.all(rows.map(async ({ doc }) => {
         try {
-          if (doc.mediaPath.indexOf(config.scanner.paths) === 0) {
+          const mediaFolder = config.scanner.paths.split('\\').join('/')
+          const mediaPath = doc.mediaPath.split('\\').join('/')
+          if (mediaPath.indexOf(mediaFolder) === 0) {
             try {
               const stat = await statAsync(doc.mediaPath)
               if (stat.isFile()) {

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -60,8 +60,8 @@ module.exports = function ({ config, db, logger }) {
       })
       await Promise.all(rows.map(async ({ doc }) => {
         try {
-          const mediaFolder = config.scanner.paths.split('\\').join('/')
-          const mediaPath = doc.mediaPath.split('\\').join('/')
+          const mediaFolder = path.normalize(config.scanner.paths)
+          const mediaPath = path.normalize(doc.mediaPath)
           if (mediaPath.indexOf(mediaFolder) === 0) {
             try {
               const stat = await statAsync(doc.mediaPath)


### PR DESCRIPTION
The file paths in committed code can contain variations in forward and backward slashes. This could cause the files to be deleted from the media database, causing a rescan.

The committed code converts all file paths to `/` slashes before comparing them such that no more unnecessary rescans are triggered.