### PR TITLE
Add return type option for TLS/CLS/FLS commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chokidar": "^2.0.0",
     "express": "^4.16.2",
     "express-pouchdb": "^4.0.0",
+    "js2xmlparser": "^3.0.0",
     "mkdirp-promise": "^5.0.1",
     "moment": "^2.20.1",
     "nconf": "^0.10.0",

--- a/src/app.js
+++ b/src/app.js
@@ -37,7 +37,7 @@ module.exports = function ({ db, config, logger }) {
       .filter(x => /\.(ft|wt|ct|html)$/.test(x))
 
     if (config.http.responseFormat === 'JSON' || config.http.responseFormat === 'XML') {
-      res.send(formatOutput(str, 'TLS', config.http.responseFormat, config) + "\r\n")
+      res.send(formatOutput(str, 'TLS', config.http.responseFormat, config))
     } else {
       const data = str.map(x => `${getId(config.paths.template, x)}\r\n`)
       .reduce((acc, inf) => acc + inf, '')

--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,8 @@ const defaults = {
     prettyPrint: process.env.NODE_ENV !== 'production'
   },
   http: {
-    port: 8000
+    port: 8000,
+    responseFormat: "SDL"
   }
 }
 
@@ -49,6 +50,9 @@ if (config.caspar && config.caspar.config) {
     }
     for (const path in result.configuration.paths[0]) {
       config.paths[path.split('-')[0]] = result.configuration.paths[0][path][0]
+    }
+    if (result.configuration.amcp[0]['media-server'][0]['response-format'][0] !== undefined) {
+      config.http.responseFormat = result.configuration.amcp[0]['media-server'][0]['response-format'][0].toUpperCase()
     }
   })
 }

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1,0 +1,81 @@
+var js2xmlparser = require("js2xmlparser");
+const { getId } = require('./util')
+
+module.exports = {
+  formatOutput(data, command, type, config) {
+    command = command.toUpperCase()
+    if (type === 'JSON' || type === 'XML') {
+      data_json = {}
+      if (command === 'CLS') {
+        data_json = toCLSJSON(data)
+      } else if (command === 'TLS') {
+        data_json = toTLSJSON(data, config)
+      } else if (command === 'FLS') {
+        data_json = toFLSJSON(data, config)
+      } else {
+        data_json = data
+      }
+
+      response = {
+        'status': '200 ' + command + ' OK',
+        'data': data_json
+      }
+
+      if (type === 'JSON') {
+        return JSON.stringify(response)
+      } else {
+        return js2xmlparser.parse("response", response)
+      }
+    } else {
+      return `200 ` + command + ` OK\r\n${data}\r\n`
+    }
+  },
+}
+
+function splitLine(line) {
+  var path = line.match(/("([^"]|"")*")/g)[0]
+  line = line.replace(path, '')
+  var data = line.split(" ").filter(value => Object.keys(value).length !== 0);
+
+  return {
+      path: path.replace(/"/g, ''),
+      type: data[0],
+      mediaSize: data[1],
+      mTime: data[2],
+      duration: data[3],
+      timeBase: data[4]
+  }
+}
+
+function toCLSJSON (str) {
+  data = str.split('\r\n').filter(value => Object.keys(value).length !== 0);
+  data.forEach(function(line, index){
+      this[index] = splitLine(line.replace(/^"(.+(?="$))"$/, '$1'))
+  }, data);
+  return data
+}
+
+function toTLSJSON (arr, config) {
+  data = []
+
+  arr.forEach(element => {
+    data.push({
+      id: getId(config.paths.template, element)
+    })
+  })
+
+  return data
+}
+
+function toFLSJSON (arr, config) {
+  data = []
+
+  arr.forEach(element => {
+    console.log(element)
+    data.push({
+      id: getId(config.paths.font, element)
+    })
+  })
+
+  return data
+}


### PR DESCRIPTION
Requested in #14 

Adds the config option `<response-format>` to `<media-server>`. Takes `SDL` (default), `JSON`, or `XML`