### PR TITLE
fix: set fixed timebase and duration for STILLs

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -201,11 +201,15 @@ module.exports = function ({ config, db, logger }) {
 
         let type = ' AUDIO '
         if (json.streams[0].pix_fmt) {
-          type = dur <= (1 / 24) ? ' STILL ' : ' MOVIE '
-
-          const fr = String(json.streams[0].avg_frame_rate || json.streams[0].r_frame_rate || '').split('/')
-          if (fr.length === 2) {
-            tb = [ fr[1], fr[0] ]
+          if (dur <= (1 / 24)) {
+            type = ' STILL '
+            tb = [0,1]
+          } else {
+            type = ' MOVIE '
+            const fr = String(json.streams[0].avg_frame_rate || json.streams[0].r_frame_rate || '').split('/')
+            if (fr.length === 2) {
+              tb = [ fr[1], fr[0] ]
+            }
           }
         }
 
@@ -214,7 +218,7 @@ module.exports = function ({ config, db, logger }) {
           type,
           doc.mediaSize,
           moment(doc.thumbTime).format('YYYYMMDDHHmmss'),
-          Math.floor((dur * tb[1]) / tb[0]),
+          tb[0] === 0 ? 0 : Math.floor((dur * tb[1]) / tb[0]),
           `${tb[0]}/${tb[1]}`
         ].join(' ') + '\r\n')
       })


### PR DESCRIPTION
Hello,

this is a fix that remove the NaN from the CLS output for STILLs. I replaced the NaN and the timebase values to the values of CasparCG 2.1's CLS output

;)