### PR TITLE
Change how ffmpeg generate thumbnails with alpha backgrounds

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -145,8 +145,9 @@ module.exports = function ({ config, db, logger }) {
       config.paths.ffmpeg,
       '-hide_banner',
       '-i', `"${doc.mediaPath}"`,
+      '-vf select=gt(scene\,0.4)',
+      `-vf scale=${config.thumbnails.width}:${config.thumbnails.height}`,
       '-frames:v 1',
-      `-vf thumbnail,scale=${config.thumbnails.width}:${config.thumbnails.height}`,
       '-threads 1',
       tmpPath
     ]


### PR DESCRIPTION
The filter thumbnail in FFmpeg is locked at rgb8 and that brakes transparent backgrounds.