### PR TITLE
fix: ensure app listens on IPv4/tcp ports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,4 +15,4 @@ const db = new PouchDB(`http://localhost:${config.http.port}/db/_media`);
 logger.info(config)
 
 scanner({ logger, db, config })
-app({ logger, db, PouchDB, config }).listen(config.http.port)
+app({ logger, db, PouchDB, config }).listen(config.http.port, '0.0.0.0')


### PR DESCRIPTION
Due to a change in the way the app dependency works, not specifying
an address (even just '0.0.0.0') means that the program would listen to
an IPv6 address/port, instead of IPv4, which nearly everything is still
configured for. This meant that the client could not see the media
scanner. This commit fixes that, by making the app dependency listen
on an IPv4 address/port.