### PR TITLE
Media file in subfolder fix

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -37,7 +37,7 @@ export default function ({ db, config, logger }: { db: any; config: any; logger:
 	)
 
 	app.get(
-		'/media/info/:id',
+		'/media/info/:id(*)',
 		wrap(async (req, res) => {
 			const { mediainfo } = await db.get(req.params.id.toUpperCase())
 			res.set('content-type', 'application/json')
@@ -46,7 +46,7 @@ export default function ({ db, config, logger }: { db: any; config: any; logger:
 	)
 
 	app.get(
-		'/media/thumbnail/:id',
+		'/media/thumbnail/:id(*)',
 		wrap(async (req, res) => {
 			const { _attachments } = await db.get(req.params.id.toUpperCase(), { attachments: true, binary: true })
 
@@ -185,7 +185,7 @@ export default function ({ db, config, logger }: { db: any; config: any; logger:
 	)
 
 	app.get(
-		'/cinf/:id',
+		'/cinf/:id(*)',
 		wrap(async (req, res) => {
 			const { cinf } = await db.get(req.params.id.toUpperCase())
 			res.set('content-type', 'text/plain')
@@ -203,7 +203,7 @@ export default function ({ db, config, logger }: { db: any; config: any; logger:
 	)
 
 	app.get(
-		'/thumbnail/generate/:id',
+		'/thumbnail/generate/:id(*)',
 		wrap(async (_req, res) => {
 			// TODO (fix) Force scanner to scan and wait?
 			res.set('content-type', 'text/plain')
@@ -224,7 +224,7 @@ export default function ({ db, config, logger }: { db: any; config: any; logger:
 	)
 
 	app.get(
-		'/thumbnail/:id',
+		'/thumbnail/:id(*)',
 		wrap(async (req, res) => {
 			const { _attachments } = await db.get(req.params.id.toUpperCase(), { attachments: true })
 


### PR DESCRIPTION
When media file was in subfolder, some request did not work, because slash swallowed by the express. 