### PR TITLE
Ignore paths that begin with underscore

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -39,6 +39,11 @@ export default function (logger: Logger, db: MediaDatabase, config: Record<strin
 		.pipe(
 			concatMap(async ([mediaPath, mediaStat]) => {
 				const mediaId = getId(config.paths.media, mediaPath)
+
+				// Filter out files that are not to be scanned
+				if (!filter(mediaId, mediaPath)) return
+
+				console.log('mediaId', mediaId)
 				try {
 					if (!mediaStat) {
 						await db.remove(await db.get(mediaId))
@@ -147,5 +152,17 @@ export default function (logger: Logger, db: MediaDatabase, config: Record<strin
 		await db.put(doc, { force: true })
 
 		mediaLogger.info('Scanned')
+	}
+	/**
+	 * Filter out files that are not to be scanned
+	 * @returns true if the media is to be scanned, false otherwise
+	 */
+	function filter(mediaId: string, _mediaPath: string): boolean {
+		if (mediaId.startsWith('_')) {
+			// PouchDB cannot store these ("Only reserved document ids may start with underscore.")
+			return false
+		}
+
+		return true
 	}
 }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -41,7 +41,7 @@ export default function (logger: Logger, db: MediaDatabase, config: Record<strin
 				const mediaId = getId(config.paths.media, mediaPath)
 
 				// Filter out files that are not to be scanned
-				if (!filter(mediaId, mediaPath)) return
+				if (!shouldFileBeScanned(mediaId, mediaPath)) return
 
 				try {
 					if (!mediaStat) {
@@ -156,7 +156,7 @@ export default function (logger: Logger, db: MediaDatabase, config: Record<strin
 	 * Filter out files that are not to be scanned
 	 * @returns true if the media is to be scanned, false otherwise
 	 */
-	function filter(mediaId: string, _mediaPath: string): boolean {
+	function shouldFileBeScanned(mediaId: string, _mediaPath: string): boolean {
 		if (mediaId.startsWith('_')) {
 			// PouchDB cannot store these ("Only reserved document ids may start with underscore.")
 			return false

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -43,7 +43,6 @@ export default function (logger: Logger, db: MediaDatabase, config: Record<strin
 				// Filter out files that are not to be scanned
 				if (!filter(mediaId, mediaPath)) return
 
-				console.log('mediaId', mediaId)
 				try {
 					if (!mediaStat) {
 						await db.remove(await db.get(mediaId))


### PR DESCRIPTION
## The problem:

I continously get a LOT of error messages in the log, on the form `Only reserved document ids may start with underscore.`.

```bash
{"level":50,"time":1705906640456,"pid":25528,"hostname":"NYTAMIN-STATION4","name":"scanner","err":{"type":"PouchError","message":"Only reserved document ids may start with underscore.","st
ack":"Error\n    at new CustomPouchError (C:\\git\\media-scanner\\node_modules\\pouchdb-node\\lib\\index.js:656:21)\n    at createError (C:\\git\\media-scanner\\node_modules\\pouchdb-node\
\lib\\index.js:665:10)\n    at invalidIdError (C:\\git\\media-scanner\\node_modules\\pouchdb-node\\lib\\index.js:794:11)\n    at PouchDB.<anonymous> (C:\\git\\media-scanner\\node_modules\\
pouchdb-node\\lib\\index.js:1754:3)\n    at PouchDB.<anonymous> (C:\\git\\media-scanner\\node_modules\\pouchdb-node\\lib\\index.js:290:21)\n    at PouchDB.<anonymous> (C:\\git\\media-scann
er\\node_modules\\argsarray\\index.js:14:18)\n    at C:\\git\\media-scanner\\node_modules\\pouchdb-node\\lib\\index.js:229:21\n    at new Promise (<anonymous>)\n    at PouchDB.<anonymous>
(C:\\git\\media-scanner\\node_modules\\pouchdb-node\\lib\\index.js:216:19)\n    at PouchDB.put (C:\\git\\media-scanner\\node_modules\\argsarray\\index.js:14:18)","status":400,"name":"bad_r
equest","error":true},"msg":"Only reserved document ids may start with underscore."}
```

Because I have a folder structure with folders that begin with underscore: `/media/_oldClips/clip.mp4`

## The fix

A simple quick fix:
Ignore any ids that begin with underscore, since they cannot be stored in PouchDB anyway, so this should result in no changes in the data written to the DB.

## Caveat

This works for me, since I mark folders with underscore in order to ignore them anyway.

But if anyone in the future wishes to scan folders with names that begin with underscore, we could instead change how we generate the ID into a hash (but that's for a later PR).

