### PR TITLE
Put framerate into mediainfo

### DIFF
--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -212,6 +212,7 @@ async function generateMediainfo(config: Record<string, any>, doc: PouchDBMediaD
 			display_aspect_ratio: s.display_aspect_ratio,
 			pix_fmt: s.pix_fmt,
 			bits_per_raw_sample: s.bits_per_raw_sample,
+			frame_rate: s.avg_frame_rate || s.r_frame_rate,
 
 			// Audio
 			sample_fmt: s.sample_fmt,


### PR DESCRIPTION
Saves framerate into mediainfo so it is visible in /media endpoint. It is needed because in some formats time_base isn't 1/framerate. https://github.com/CasparCG/media-scanner/issues/87